### PR TITLE
BitmapData.js: fixed fluent interface

### DIFF
--- a/src/gameobjects/BitmapData.js
+++ b/src/gameobjects/BitmapData.js
@@ -1730,6 +1730,8 @@ Phaser.BitmapData.prototype = {
             ctx.shadowOffsetX = x || 10;
             ctx.shadowOffsetY = y || 10;
         }
+        
+        return this;
 
     },
 
@@ -1881,6 +1883,8 @@ Phaser.BitmapData.prototype = {
         ctx.fillText(text, x, y);
 
         ctx.font = prevFont;
+        
+        return this;
 
     },
 


### PR DESCRIPTION
In `BitmapData` docs it is saying `BitmapData`'s methods always return `this` for chaining, but for `text` and `shadow` methods, `return this` was missing.
